### PR TITLE
feat: Live demo profiling top 10 Docker Hub images with Grafana dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Thumbs.db
 .dockpulse/
 *.db
 
+# Demo generated reports
+examples/demo/demo-report.html
+
 # Environment
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ Container   Image          Create→Running   Running→Healthy   Total      Ima
 nginx       nginx:latest   142ms            —                 142ms      187.8 MB     ✗
 ```
 
+### Live Demo: Top 10 Docker Hub Images
+
+See DockPulse in action profiling the most popular containers on Docker Hub — nginx, redis, postgres, python, node, memcached, mysql, mongo, httpd, and rabbitmq — with deliberately over-provisioned limits so you can see waste detection, right-sizing, and Grafana dashboards working end to end.
+
+```bash
+cd examples/demo
+./run-demo.sh
+```
+
+The script pulls all 10 images, starts a traffic generator, profiles for 3 minutes, launches Prometheus + Grafana, and generates analysis, waste, cost, and HTML reports automatically. See [`examples/demo/README.md`](examples/demo/README.md) for options.
+
 ### Grafana Dashboards
 
 DockPulse ships with three pre-built Grafana dashboards and Prometheus recording/alerting rules. To use them with the bundled Prometheus setup:

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,0 +1,58 @@
+# DockPulse Live Demo
+
+Profile the **top 10 most popular Docker Hub images** and visualize the results in Grafana.
+
+## What's Included
+
+| Container | Image | Purpose | Deliberate Misconfiguration |
+|-----------|-------|---------|----------------------------|
+| nginx | `nginx:alpine` | Web server | 512M limit for ~5M actual usage |
+| redis | `redis:7-alpine` | In-memory cache | Moderate over-provisioning |
+| postgres | `postgres:16-alpine` | Relational DB | 2048M limit, mostly idle |
+| python-api | `python:3.12-slim` | API with CPU work | CPU-intensive hash computation |
+| node-worker | `node:20-alpine` | Background worker | Periodic JSON serialization |
+| memcached | `memcached:alpine` | Distributed cache | 512M limit for 32M config |
+| mysql | `mysql:8.0` | Relational DB | 2048M limit, mostly idle |
+| mongo | `mongo:7` | Document DB | 1024M limit, mostly idle |
+| httpd | `httpd:alpine` | Web server | 512M limit for comparison |
+| rabbitmq | `rabbitmq:3-management` | Message broker | Management UI enabled |
+
+A **traffic generator** sends HTTP requests to nginx, httpd, and the Python API to produce realistic network I/O.
+
+## Quick Start
+
+```bash
+cd examples/demo
+./run-demo.sh
+```
+
+This will:
+1. Pull and start all 10 containers + traffic generator
+2. Start Prometheus + Grafana (auto-provisioned dashboards)
+3. Start the DockPulse Prometheus exporter
+4. Profile all containers for 3 minutes
+5. Generate analysis, waste report, HTML report, and cost estimate
+
+## Options
+
+```bash
+./run-demo.sh --duration 5m      # Longer profiling window
+./run-demo.sh --skip-grafana     # Skip the Grafana stack
+./run-demo.sh --cleanup          # Tear down everything
+```
+
+## Grafana Dashboards
+
+After running the demo, open **http://localhost:3000** (admin/admin):
+
+- **Container Resource Overview** — CPU, memory, network, disk I/O across all containers
+- **Alerts & Thresholds** — active alerts, threshold monitoring, 5m rolling aggregates
+- **Right-Sizing & Waste Analysis** — fleet utilization, waste metrics, usage vs limits
+
+The dashboards update in real time as long as the exporter is running.
+
+## Cleanup
+
+```bash
+./run-demo.sh --cleanup
+```

--- a/examples/demo/docker-compose.yml
+++ b/examples/demo/docker-compose.yml
@@ -1,0 +1,258 @@
+# DockPulse Live Demo
+#
+# Spins up the top 10 most popular Docker Hub images with realistic workloads
+# and deliberate over/under-provisioning so DockPulse can demonstrate:
+#   - Resource profiling across a diverse container fleet
+#   - Waste detection on over-provisioned containers
+#   - Anomaly detection on CPU-intensive workloads
+#   - Right-sizing recommendations
+#   - Grafana dashboard visualization
+#
+# Usage:
+#   cd examples/demo
+#   ./run-demo.sh          # orchestrates everything
+#
+#   Or manually:
+#     docker compose up -d
+#     dockpulse profile --duration 3m
+#     dockpulse analyze
+#     dockpulse waste
+
+services:
+  # ---------- 1. nginx (most pulled image on Docker Hub) ----------
+  # Serves static content. Massively over-provisioned to show waste.
+  nginx:
+    image: nginx:alpine
+    container_name: demo-nginx
+    ports:
+      - "8080:80"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "2.0"
+        reservations:
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # ---------- 2. redis ----------
+  # In-memory cache. Moderate allocation, low actual usage.
+  redis:
+    image: redis:7-alpine
+    container_name: demo-redis
+    command: redis-server --maxmemory 64mb --maxmemory-policy allkeys-lru
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "1.0"
+        reservations:
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # ---------- 3. postgres ----------
+  # Relational database. Heavily over-provisioned for demo waste detection.
+  postgres:
+    image: postgres:16-alpine
+    container_name: demo-postgres
+    environment:
+      POSTGRES_USER: dockpulse
+      POSTGRES_PASSWORD: dockpulse
+      POSTGRES_DB: demo
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          memory: 2048M
+          cpus: "2.0"
+        reservations:
+          memory: 512M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dockpulse"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # ---------- 4. python (API workload) ----------
+  # Simulates a Python API server doing periodic CPU-heavy work.
+  python-api:
+    image: python:3.12-slim
+    container_name: demo-python-api
+    command: >
+      python -c "
+      import http.server, time, threading, hashlib, os
+      def cpu_work():
+          while True:
+              for _ in range(50):
+                  hashlib.sha256(os.urandom(4096)).hexdigest()
+              time.sleep(0.3)
+      threading.Thread(target=cpu_work, daemon=True).start()
+      http.server.HTTPServer(('', 8000), http.server.SimpleHTTPRequestHandler).serve_forever()
+      "
+    ports:
+      - "8000:8000"
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+          cpus: "2.0"
+        reservations:
+          memory: 256M
+
+  # ---------- 5. node (background worker) ----------
+  # Simulates a Node.js worker doing periodic JSON processing.
+  node-worker:
+    image: node:20-alpine
+    container_name: demo-node-worker
+    command: >
+      node -e "
+      setInterval(() => {
+        const data = Array.from({length: 10000}, (_, i) => ({id: i, value: Math.random()}));
+        JSON.parse(JSON.stringify(data));
+      }, 500);
+      console.log('Node worker running...');
+      setInterval(() => {}, 60000);
+      "
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+        reservations:
+          memory: 128M
+
+  # ---------- 6. memcached ----------
+  # Distributed cache. Deliberately over-provisioned.
+  memcached:
+    image: memcached:alpine
+    container_name: demo-memcached
+    command: memcached -m 32
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+        reservations:
+          memory: 64M
+
+  # ---------- 7. mysql ----------
+  # Another popular database. Over-provisioned relative to idle usage.
+  mysql:
+    image: mysql:8.0
+    container_name: demo-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: dockpulse
+      MYSQL_DATABASE: demo
+    volumes:
+      - mysqldata:/var/lib/mysql
+    deploy:
+      resources:
+        limits:
+          memory: 2048M
+          cpus: "2.0"
+        reservations:
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
+
+  # ---------- 8. mongo ----------
+  # Document database. Over-provisioned for waste demo.
+  mongo:
+    image: mongo:7
+    container_name: demo-mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: dockpulse
+      MONGO_INITDB_ROOT_PASSWORD: dockpulse
+    volumes:
+      - mongodata:/data/db
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+          cpus: "2.0"
+        reservations:
+          memory: 256M
+
+  # ---------- 9. httpd (Apache) ----------
+  # Classic web server. Over-provisioned for comparison with nginx.
+  httpd:
+    image: httpd:alpine
+    container_name: demo-httpd
+    ports:
+      - "8081:80"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+        reservations:
+          memory: 128M
+
+  # ---------- 10. rabbitmq (message broker) ----------
+  # Message queue with management UI. Moderate allocation.
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: demo-rabbitmq
+    ports:
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: dockpulse
+      RABBITMQ_DEFAULT_PASS: dockpulse
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+        reservations:
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # ---------- Traffic generator ----------
+  # Drives HTTP requests to nginx, httpd, and the Python API to produce
+  # realistic network I/O and varied CPU load.
+  traffic-gen:
+    image: alpine:latest
+    container_name: demo-traffic-gen
+    command: >
+      sh -c "
+      apk add --no-cache curl > /dev/null 2>&1;
+      echo 'Generating traffic...';
+      while true; do
+        curl -s http://nginx/ > /dev/null 2>&1;
+        curl -s http://httpd/ > /dev/null 2>&1;
+        curl -s http://python-api:8000/ > /dev/null 2>&1;
+        sleep 0.5;
+      done
+      "
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+          cpus: "0.25"
+    depends_on:
+      - nginx
+      - httpd
+      - python-api
+
+volumes:
+  pgdata:
+  mysqldata:
+  mongodata:

--- a/examples/demo/run-demo.sh
+++ b/examples/demo/run-demo.sh
@@ -79,10 +79,20 @@ if ! docker info &>/dev/null 2>&1; then
     exit 1
 fi
 
+# Activate the project venv if it exists and dockpulse isn't already available
+if ! command -v dockpulse &>/dev/null; then
+    if [[ -f "$REPO_ROOT/.venv/bin/activate" ]]; then
+        info "Activating project virtualenv..."
+        # shellcheck disable=SC1091
+        source "$REPO_ROOT/.venv/bin/activate"
+    fi
+fi
+
 if ! command -v dockpulse &>/dev/null; then
     warn "dockpulse not found in PATH. Trying pip install..."
-    pip install -e "$REPO_ROOT" 2>/dev/null || {
-        error "Failed to install dockpulse. Install it with: pip install -e ."
+    pip install -e "$REPO_ROOT" || {
+        error "Failed to install dockpulse."
+        error "Activate your virtualenv first, or run: pip install -e $REPO_ROOT"
         exit 1
     }
 fi

--- a/examples/demo/run-demo.sh
+++ b/examples/demo/run-demo.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# DockPulse Live Demo
+#
+# Spins up the top 10 most popular Docker Hub images, profiles them with
+# DockPulse, starts Prometheus + Grafana, and generates reports.
+#
+# Usage:
+#   ./run-demo.sh                  # Full demo (3-minute profile)
+#   ./run-demo.sh --duration 5m    # Custom profiling duration
+#   ./run-demo.sh --skip-grafana   # Skip Prometheus/Grafana stack
+#   ./run-demo.sh --cleanup        # Tear everything down
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DURATION="${DURATION:-3m}"
+SKIP_GRAFANA=false
+CLEANUP_ONLY=false
+
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[DockPulse Demo]${NC} $*"; }
+ok()    { echo -e "${GREEN}[✓]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+error() { echo -e "${RED}[✗]${NC} $*"; }
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --duration DURATION   Profiling duration (default: 3m)"
+    echo "  --skip-grafana        Skip Prometheus + Grafana stack"
+    echo "  --cleanup             Tear down all demo containers and exit"
+    echo "  -h, --help            Show this help message"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --duration)    DURATION="$2"; shift 2 ;;
+        --skip-grafana) SKIP_GRAFANA=true; shift ;;
+        --cleanup)     CLEANUP_ONLY=true; shift ;;
+        -h|--help)     usage ;;
+        *)             error "Unknown option: $1"; usage ;;
+    esac
+done
+
+cleanup() {
+    info "Tearing down demo containers..."
+    docker compose -f "$SCRIPT_DIR/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+    if [[ "$SKIP_GRAFANA" == false ]]; then
+        docker compose -f "$REPO_ROOT/examples/prometheus/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+    fi
+    ok "Cleanup complete."
+}
+
+if [[ "$CLEANUP_ONLY" == true ]]; then
+    cleanup
+    exit 0
+fi
+
+# ── Preflight checks ───────────────────────────────────────────────
+info "Running preflight checks..."
+
+if ! command -v docker &>/dev/null; then
+    error "Docker is not installed. Please install Docker first."
+    exit 1
+fi
+
+if ! docker info &>/dev/null 2>&1; then
+    error "Docker daemon is not running. Please start Docker first."
+    exit 1
+fi
+
+if ! command -v dockpulse &>/dev/null; then
+    warn "dockpulse not found in PATH. Trying pip install..."
+    pip install -e "$REPO_ROOT" 2>/dev/null || {
+        error "Failed to install dockpulse. Install it with: pip install -e ."
+        exit 1
+    }
+fi
+
+ok "All preflight checks passed."
+
+# ── Step 1: Start the top 10 containers ────────────────────────────
+echo ""
+echo -e "${BOLD}━━━ Step 1/5: Starting Top 10 Docker Hub Containers ━━━${NC}"
+info "Pulling and starting containers..."
+
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d --pull always
+
+info "Waiting for containers to stabilize (30 seconds)..."
+sleep 30
+
+RUNNING=$(docker compose -f "$SCRIPT_DIR/docker-compose.yml" ps --status running -q | wc -l | tr -d ' ')
+ok "$RUNNING containers running."
+
+# ── Step 2: Start Prometheus + Grafana ─────────────────────────────
+if [[ "$SKIP_GRAFANA" == false ]]; then
+    echo ""
+    echo -e "${BOLD}━━━ Step 2/5: Starting Prometheus + Grafana ━━━${NC}"
+    docker compose -f "$REPO_ROOT/examples/prometheus/docker-compose.yml" up -d
+    ok "Prometheus running at http://localhost:9091"
+    ok "Grafana running at http://localhost:3000 (admin/admin)"
+fi
+
+# ── Step 3: Start DockPulse Prometheus exporter ────────────────────
+echo ""
+echo -e "${BOLD}━━━ Step 3/5: Starting DockPulse Prometheus Exporter ━━━${NC}"
+
+# Kill any existing exporter
+pkill -f "dockpulse export" 2>/dev/null || true
+sleep 1
+
+dockpulse export --port 9090 &
+EXPORTER_PID=$!
+sleep 2
+
+if kill -0 $EXPORTER_PID 2>/dev/null; then
+    ok "Prometheus exporter running at http://localhost:9090/metrics (PID: $EXPORTER_PID)"
+else
+    error "Failed to start Prometheus exporter."
+    exit 1
+fi
+
+# ── Step 4: Profile containers ─────────────────────────────────────
+echo ""
+echo -e "${BOLD}━━━ Step 4/5: Profiling Containers (${DURATION}) ━━━${NC}"
+info "This will take ${DURATION}. Data streams to Grafana in real time."
+if [[ "$SKIP_GRAFANA" == false ]]; then
+    info "Open Grafana now: ${BOLD}http://localhost:3000${NC}"
+    echo ""
+    info "  Dashboards:"
+    info "    • Container Resource Overview  → /d/dockpulse-overview"
+    info "    • Alerts & Thresholds          → /d/dockpulse-alerts"
+    info "    • Right-Sizing & Waste         → /d/dockpulse-rightsizing"
+    echo ""
+fi
+
+dockpulse profile --duration "$DURATION"
+ok "Profiling complete."
+
+# ── Step 5: Generate reports ───────────────────────────────────────
+echo ""
+echo -e "${BOLD}━━━ Step 5/5: Generating Reports ━━━${NC}"
+
+info "Analysis results:"
+echo ""
+dockpulse analyze
+echo ""
+
+info "Waste report:"
+echo ""
+dockpulse waste
+echo ""
+
+info "Generating interactive HTML report..."
+REPORT_PATH="$SCRIPT_DIR/demo-report.html"
+dockpulse report --output "$REPORT_PATH" --type profile
+ok "HTML report saved to $REPORT_PATH"
+
+info "Cost estimation (AWS Fargate):"
+echo ""
+dockpulse cost --provider aws
+echo ""
+
+# ── Summary ────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}${BOLD}  Demo Complete!${NC}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "  ${BOLD}Containers profiled:${NC}  $RUNNING"
+echo -e "  ${BOLD}HTML report:${NC}          $REPORT_PATH"
+if [[ "$SKIP_GRAFANA" == false ]]; then
+    echo -e "  ${BOLD}Grafana dashboards:${NC}   http://localhost:3000 (admin/admin)"
+    echo -e "  ${BOLD}Prometheus:${NC}           http://localhost:9091"
+fi
+echo -e "  ${BOLD}Metrics endpoint:${NC}     http://localhost:9090/metrics"
+echo ""
+echo -e "  ${BOLD}Explore further:${NC}"
+echo -e "    dockpulse sessions           # list profiling sessions"
+echo -e "    dockpulse right-size examples/demo/docker-compose.yml"
+echo -e "    dockpulse stack examples/demo/docker-compose.yml"
+echo ""
+echo -e "  ${BOLD}Cleanup:${NC}"
+echo -e "    ./run-demo.sh --cleanup      # tear down all containers"
+echo ""
+echo -e "  ${YELLOW}Note: Prometheus exporter is still running (PID: $EXPORTER_PID).${NC}"
+echo -e "  ${YELLOW}Grafana dashboards continue to update in real time.${NC}"
+echo -e "  ${YELLOW}Kill the exporter with: kill $EXPORTER_PID${NC}"

--- a/examples/demo/run-demo.sh
+++ b/examples/demo/run-demo.sh
@@ -104,7 +104,8 @@ echo ""
 echo -e "${BOLD}━━━ Step 1/5: Starting Top 10 Docker Hub Containers ━━━${NC}"
 info "Pulling and starting containers..."
 
-docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d --pull always
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" pull
+docker compose -f "$SCRIPT_DIR/docker-compose.yml" up -d
 
 info "Waiting for containers to stabilize (30 seconds)..."
 sleep 30

--- a/src/dockpulse/cli.py
+++ b/src/dockpulse/cli.py
@@ -57,6 +57,7 @@ def _load_profiles_from_db(db_path: str) -> list[ProfileResult]:
         raise typer.Exit(1)
 
     conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
     rows = conn.execute("SELECT * FROM samples ORDER BY name, timestamp").fetchall()
     conn.close()
 
@@ -67,18 +68,18 @@ def _load_profiles_from_db(db_path: str) -> list[ProfileResult]:
     grouped: dict[str, list[ContainerStats]] = {}
     for row in rows:
         stat = ContainerStats(
-            container_id=row[0],
-            name=row[1],
-            timestamp=datetime.fromisoformat(row[2]).replace(tzinfo=timezone.utc),
-            cpu_percent=row[3],
-            memory_usage_mb=row[4],
-            memory_limit_mb=row[5],
-            memory_percent=row[6],
-            network_rx_mb=row[7],
-            network_tx_mb=row[8],
-            block_read_mb=row[9],
-            block_write_mb=row[10],
-            pids=row[11],
+            container_id=row["container_id"],
+            name=row["name"],
+            timestamp=datetime.fromisoformat(row["timestamp"]).replace(tzinfo=timezone.utc),
+            cpu_percent=row["cpu_percent"],
+            memory_usage_mb=row["memory_usage_mb"],
+            memory_limit_mb=row["memory_limit_mb"],
+            memory_percent=row["memory_percent"],
+            network_rx_mb=row["network_rx_mb"],
+            network_tx_mb=row["network_tx_mb"],
+            block_read_mb=row["block_read_mb"],
+            block_write_mb=row["block_write_mb"],
+            pids=row["pids"],
         )
         grouped.setdefault(stat.name, []).append(stat)
 
@@ -97,6 +98,7 @@ def _load_samples_for_session(db_path: str, session_id: str) -> list[ProfileResu
         raise typer.Exit(1)
 
     conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
 
     # Check if sessions table exists
     table_check = conn.execute(
@@ -118,7 +120,7 @@ def _load_samples_for_session(db_path: str, session_id: str) -> list[ProfileResu
         conn.close()
         raise typer.Exit(1)
 
-    _full_session_id, started_at, ended_at = row
+    _full_session_id, started_at, ended_at = row["session_id"], row["started_at"], row["ended_at"]
 
     query = "SELECT * FROM samples WHERE timestamp >= ? ORDER BY name, timestamp"
     params: list[str] = [started_at]
@@ -138,18 +140,18 @@ def _load_samples_for_session(db_path: str, session_id: str) -> list[ProfileResu
     grouped: dict[str, list[ContainerStats]] = {}
     for r in rows:
         stat = ContainerStats(
-            container_id=r[0],
-            name=r[1],
-            timestamp=datetime.fromisoformat(r[2]).replace(tzinfo=timezone.utc),
-            cpu_percent=r[3],
-            memory_usage_mb=r[4],
-            memory_limit_mb=r[5],
-            memory_percent=r[6],
-            network_rx_mb=r[7],
-            network_tx_mb=r[8],
-            block_read_mb=r[9],
-            block_write_mb=r[10],
-            pids=r[11],
+            container_id=r["container_id"],
+            name=r["name"],
+            timestamp=datetime.fromisoformat(r["timestamp"]).replace(tzinfo=timezone.utc),
+            cpu_percent=r["cpu_percent"],
+            memory_usage_mb=r["memory_usage_mb"],
+            memory_limit_mb=r["memory_limit_mb"],
+            memory_percent=r["memory_percent"],
+            network_rx_mb=r["network_rx_mb"],
+            network_tx_mb=r["network_tx_mb"],
+            block_read_mb=r["block_read_mb"],
+            block_write_mb=r["block_write_mb"],
+            pids=r["pids"],
         )
         grouped.setdefault(stat.name, []).append(stat)
 

--- a/src/dockpulse/visualizer.py
+++ b/src/dockpulse/visualizer.py
@@ -27,6 +27,14 @@ _BORDER = "#334155"
 
 _CHART_COLORS = [_PRIMARY, _SUCCESS, _WARNING, _DANGER, "#a78bfa", "#fb923c", "#2dd4bf"]
 
+
+def _hex_to_rgba(hex_color: str, alpha: float = 1.0) -> str:
+    """Convert a hex color like ``#38bdf8`` to ``rgba(56,189,248,0.15)``."""
+    h = hex_color.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"rgba({r},{g},{b},{alpha})"
+
+
 _PLOTLY_LAYOUT_DEFAULTS: dict = dict(
     paper_bgcolor=_SURFACE,
     plot_bgcolor=_BG,
@@ -450,14 +458,13 @@ class Visualizer:
             values = [p.cpu_p95, p.memory_p95_mb, net_rx, disk_io, avg_pids]
 
             color = _CHART_COLORS[idx % len(_CHART_COLORS)]
+            fill = _hex_to_rgba(color, 0.15)
             fig.add_trace(
                 go.Scatterpolar(
                     r=[*values, values[0]],
                     theta=[*categories, categories[0]],
                     fill="toself",
-                    fillcolor=color.replace(")", ",0.15)").replace("rgb", "rgba")
-                    if color.startswith("rgb")
-                    else color + "26",
+                    fillcolor=fill,
                     line=dict(color=color, width=2),
                     name=p.name,
                     hovertemplate="%{theta}: %{r:.2f}<extra>%{fullData.name}</extra>",


### PR DESCRIPTION
## Summary

- **Demo compose file** (`examples/demo/docker-compose.yml`) with the 10 most popular Docker Hub images, each with deliberate over-provisioning to showcase DockPulse's capabilities:

  | Container | Image | Highlight |
  |-----------|-------|-----------|
  | nginx | `nginx:alpine` | 512M limit for ~5M actual — massive waste |
  | redis | `redis:7-alpine` | 256M limit, 64M configured max |
  | postgres | `postgres:16-alpine` | 2048M limit, mostly idle |
  | python-api | `python:3.12-slim` | CPU-intensive hash computation |
  | node-worker | `node:20-alpine` | Periodic JSON serialization bursts |
  | memcached | `memcached:alpine` | 512M limit for 32M config |
  | mysql | `mysql:8.0` | 2048M limit, mostly idle |
  | mongo | `mongo:7` | 1024M limit, mostly idle |
  | httpd | `httpd:alpine` | 512M limit for comparison with nginx |
  | rabbitmq | `rabbitmq:3-management` | Moderate allocation with mgmt UI |

- **Traffic generator** (alpine + curl) drives HTTP requests to nginx, httpd, and python-api for realistic network I/O
- **`run-demo.sh`** orchestration script that:
  1. Pulls and starts all containers
  2. Launches Prometheus + Grafana (auto-provisioned dashboards)
  3. Starts the DockPulse Prometheus exporter
  4. Profiles all containers for a configurable duration (default 3m)
  5. Generates analysis, waste, cost, and interactive HTML reports
- **Demo README** with container descriptions, quick-start, and options
- **Main README** updated with live demo section
- `.gitignore` updated for generated report file

## Test plan

- [x] Lint, format, and all 108 tests pass
- [ ] `./run-demo.sh` pulls images, starts containers, profiles, and generates reports
- [ ] Grafana dashboards show data for all 10 containers
- [ ] `./run-demo.sh --cleanup` tears down everything cleanly
- [ ] `./run-demo.sh --duration 1m --skip-grafana` works with options


Made with [Cursor](https://cursor.com)