### PR TITLE
feat: Automate GitHub Releases and Docker Hub on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Release
 
 on:
   push:
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
   id-token: write
+
+env:
+  DOCKER_IMAGE: hariharanragothaman/dockpulse
 
 jobs:
   ci:
@@ -33,6 +36,9 @@ jobs:
       - name: Install build tools
         run: pip install build
 
+      # ------------------------------------------------------------------
+      # 1. Version bump
+      # ------------------------------------------------------------------
       - name: Determine version bump
         id: bump
         env:
@@ -71,12 +77,47 @@ jobs:
         run: |
           sed -i "s/__version__ = \"${{ steps.bump.outputs.current }}\"/__version__ = \"${{ steps.bump.outputs.new }}\"/" src/dockpulse/__init__.py
 
-      - name: Build package
+      # ------------------------------------------------------------------
+      # 2. PyPI publish (Trusted Publishing / OIDC — no secrets needed)
+      # ------------------------------------------------------------------
+      - name: Build Python package
         run: python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+      # ------------------------------------------------------------------
+      # 3. Docker Hub publish
+      #    Requires repo secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+      #    Enable by setting repo variable: ENABLE_DOCKER_PUBLISH = true
+      # ------------------------------------------------------------------
+      - name: Log in to Docker Hub
+        if: vars.ENABLE_DOCKER_PUBLISH == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: vars.ENABLE_DOCKER_PUBLISH == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ steps.bump.outputs.new }}
+            ${{ env.DOCKER_IMAGE }}:latest
+
+      - name: Skip Docker Hub (not enabled)
+        if: vars.ENABLE_DOCKER_PUBLISH != 'true'
+        run: |
+          echo "::notice::Docker Hub publish skipped. To enable:"
+          echo "::notice::  1. Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repo secrets"
+          echo "::notice::  2. Set ENABLE_DOCKER_PUBLISH repo variable to true"
+
+      # ------------------------------------------------------------------
+      # 4. Commit version bump + git tag
+      # ------------------------------------------------------------------
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
@@ -90,3 +131,14 @@ jobs:
         run: |
           git tag "v${{ steps.bump.outputs.new }}"
           git push origin "v${{ steps.bump.outputs.new }}"
+
+      # ------------------------------------------------------------------
+      # 5. GitHub Release (uses GITHUB_TOKEN — no extra secrets needed)
+      # ------------------------------------------------------------------
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.bump.outputs.new }}" \
+            --title "v${{ steps.bump.outputs.new }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

Extends the existing release workflow to automate all three publish targets on merge to `main`:

- **PyPI** — unchanged, uses Trusted Publishing (OIDC, no secrets)
- **GitHub Release** — creates a release with auto-generated notes (no extra secrets)
- **Docker Hub** — builds and pushes versioned + `latest` tags (opt-in via repo variable)

## What changes

- Renames workflow from "Publish to PyPI" → "Release"
- Adds `gh release create` step after git tag push
- Adds Docker build/push gated behind `ENABLE_DOCKER_PUBLISH` repo variable
- Docker skipped with a notice until secrets + variable are configured

## Setup (one-time, in order)

### 1. PyPI — verify Trusted Publishing
Already configured. Confirm at pypi.org → dockpulse → Publishing → pending publisher points to `publish.yml`.

### 2. GitHub Releases — nothing to do
Uses built-in `GITHUB_TOKEN`. Works immediately after this PR merges.

### 3. Docker Hub — add when ready
1. Create a Docker Hub access token (Read/Write/Delete)
2. Add repo secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
3. Add repo variable: `ENABLE_DOCKER_PUBLISH` = `true`

## Test plan

- [ ] Merge this PR to `main`
- [ ] Verify GitHub Release is created on next merge (e.g. `v0.4.0`)
- [ ] Verify PyPI publish still works
- [ ] After Docker secrets + variable are set, verify image push to `hariharanragothaman/dockpulse`


Made with [Cursor](https://cursor.com)